### PR TITLE
Install kumunoito artifacts: launch files, libraries and binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   genmsg
-  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -103,7 +102,7 @@ find_package(catkin REQUIRED COMPONENTS
 #add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
 
 ## Generate added messages and services
-generate_messages(DEPENDENCIES std_msgs)
+#generate_messages(DEPENDENCIES std_msgs)
 
 ###################################
 ## catkin specific configuration ##
@@ -118,7 +117,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES kumonoito
   CATKIN_DEPENDS roscpp std_msgs genmsg
-  DEPENDS system_lib
 )
 
 ###########
@@ -138,6 +136,8 @@ add_definitions(-std=c++11)
 # add_library(${PROJECT_NAME}
 #   src/${PROJECT_NAME}/kumonoito.cc
 # )
+
+# Libraries
 
 add_library(jaco_common src/jaco_common.cc
         src/controlled_jaco_simulation.cc
@@ -165,6 +165,11 @@ target_link_libraries(ros_subscriber_system
         drake::drake
         ${catkin_LIBRARIES})
 
+install(TARGETS jaco_common ros_joint_state_publisher ros_tf_publisher ros_publisher_system ros_subscriber_system
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+# Binaries
 
 add_executable(jaco_passive_simulation_demo src/jaco_passive_simulation_demo.cc)
 target_link_libraries(jaco_passive_simulation_demo
@@ -181,6 +186,11 @@ target_link_libraries(controlled_jaco_simulation_demo
         ros_joint_state_publisher
         ros_tf_publisher
         ros_subscriber_system)
+
+install(TARGETS jaco_passive_simulation_demo controlled_jaco_simulation_demo
+   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 #
 ## WIP : Planner process that publishes JointTrajectory
 #add_executable(robot_table_planner src/robot_table_planner.cc)
@@ -218,6 +228,10 @@ target_link_libraries(controlled_jaco_simulation_demo
 #############
 ## Install ##
 #############
+
+install(DIRECTORY launch models
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ project(kumonoito)
 
 find_package(drake CONFIG REQUIRED)
 
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -15,94 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   genmsg
 )
-
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-
-## Declare ROS messages and services
-#add_message_files(DIRECTORY msg FILES Num.msg)
-#add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
-
-## Generate added messages and services
-#generate_messages(DEPENDENCIES std_msgs)
 
 ###################################
 ## catkin specific configuration ##
@@ -131,11 +42,6 @@ include_directories(
 )
 
 add_definitions(-std=c++11)
-
-# Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/kumonoito.cc
-# )
 
 # Libraries
 
@@ -200,31 +106,6 @@ install(TARGETS jaco_passive_simulation_demo controlled_jaco_simulation_demo
 #        ros_joint_state_publisher
 #        ros_publisher_system)
 
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/kumonoito_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
 #############
 ## Install ##
 #############
@@ -232,47 +113,3 @@ install(TARGETS jaco_passive_simulation_demo controlled_jaco_simulation_demo
 install(DIRECTORY launch models
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_kumonoito.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,7 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>genmsg</build_depend>
   <exec_depend>genmsg</exec_depend>


### PR DESCRIPTION
catkin supports the action of "installing" build artifacts and other necessary files using the cmake install command and the `CATKIN_PACKAGE_*_DESTINATION` variables. You can use `catkin_make install` to install them inside `~/catkin_ws/install` and the `source ~/catkin_ws/install/setup.bash` in order to configure your terminal to have access to them.

I've added in this PR the instructions to install libraries, binaries, launch files and models.

As a side note, I've removed a couple of catkin warnings related to message generation (not currently in use) or the dependency on system_lib (unnecessary).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naveenoid/kumonoito/4)
<!-- Reviewable:end -->
