### PR TITLE
Migrate code to use ros_drake wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,264 +1,55 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kumonoito)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-find_package(drake CONFIG REQUIRED)
-
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  std_msgs
-  genmsg
-  message_generation
+  ros_drake
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-
-## Declare ROS messages and services
-#add_message_files(DIRECTORY msg FILES Num.msg)
-#add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
-
-## Generate added messages and services
-generate_messages(DEPENDENCIES std_msgs)
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES kumonoito
-  CATKIN_DEPENDS roscpp std_msgs genmsg
-  DEPENDS system_lib
 )
 
 ###########
 ## Build ##
 ###########
 
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
 include_directories(
-# include
   ${catkin_INCLUDE_DIRS}
 )
-
-add_definitions(-std=c++11)
-
-# Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/kumonoito.cc
-# )
 
 add_library(jaco_common src/jaco_common.cc
         src/controlled_jaco_simulation.cc
         src/ros_subscriber_system.cc src/ros_publisher_system.cc src/robot_table_planner.cc)
-target_link_libraries(jaco_common drake::drake)
+target_link_libraries(jaco_common ${catkin_LIBRARIES})
 
 add_library(ros_joint_state_publisher src/ros_joint_state_publisher.cc)
 target_link_libraries(ros_joint_state_publisher
-        drake::drake
         ${catkin_LIBRARIES})
 
 add_library(ros_tf_publisher src/ros_tf_publisher.cc)
 target_link_libraries(ros_tf_publisher
-        drake::drake
         ${catkin_LIBRARIES})
 
 add_library(ros_publisher_system src/ros_publisher_system.cc)
 target_link_libraries(ros_publisher_system
-        drake::drake
         ${catkin_LIBRARIES})
-
 
 add_library(ros_subscriber_system src/ros_subscriber_system.cc)
 target_link_libraries(ros_subscriber_system
-        drake::drake
         ${catkin_LIBRARIES})
 
 
 add_executable(jaco_passive_simulation_demo src/jaco_passive_simulation_demo.cc)
 target_link_libraries(jaco_passive_simulation_demo
         jaco_common
-        drake::drake
-#        gflags
         ros_joint_state_publisher
         ${catkin_LIBRARIES})
 
 add_executable(controlled_jaco_simulation_demo src/controlled_jaco_simulation.cc)
 target_link_libraries(controlled_jaco_simulation_demo
         jaco_common
-        drake::drake
         ros_joint_state_publisher
         ros_tf_publisher
         ros_subscriber_system)
-#
-## WIP : Planner process that publishes JointTrajectory
-#add_executable(robot_table_planner src/robot_table_planner.cc)
-#target_link_libraries(robot_table_planner
-#        jaco_common
-#        drake::drake
-#        ros_joint_state_publisher
-#        ros_publisher_system)
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/kumonoito_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_kumonoito.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,28 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kumonoito)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  ros_drake
+find_package(catkin REQUIRED
+  COMPONENTS
+    joint_state_publisher
+    robot_state_publisher
+    ros_drake
+    roscpp
+    rosgraph_msgs
+    sensor_msgs
 )
 
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES kumonoito
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    kumonoito
+  CATKIN_DEPENDS
+    joint_state_publisher
+    robot_state_publisher
+    ros_drake
+    roscpp
+    rosgraph_msgs
+    sensor_msgs
 )
 
 ###########
@@ -16,17 +30,22 @@ catkin_package(
 ###########
 
 include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
 )
 
 add_library(jaco_common src/jaco_common.cc
         src/controlled_jaco_simulation.cc
-        src/ros_subscriber_system.cc src/ros_publisher_system.cc src/robot_table_planner.cc)
+        src/ros_subscriber_system.cc
+        src/ros_publisher_system.cc
+        src/robot_table_planner.cc)
 target_link_libraries(jaco_common ${catkin_LIBRARIES})
 
 add_library(ros_joint_state_publisher src/ros_joint_state_publisher.cc)
 target_link_libraries(ros_joint_state_publisher
         ${catkin_LIBRARIES})
+# ros_joint_state_publisher depends on rosgraph_msgs, needs the catkin_EXPORTED_TARGETS
+add_dependencies(ros_joint_state_publisher ${catkin_EXPORTED_TARGETS})
 
 add_library(ros_tf_publisher src/ros_tf_publisher.cc)
 target_link_libraries(ros_tf_publisher
@@ -40,7 +59,6 @@ add_library(ros_subscriber_system src/ros_subscriber_system.cc)
 target_link_libraries(ros_subscriber_system
         ${catkin_LIBRARIES})
 
-
 add_executable(jaco_passive_simulation_demo src/jaco_passive_simulation_demo.cc)
 target_link_libraries(jaco_passive_simulation_demo
         jaco_common
@@ -53,3 +71,23 @@ target_link_libraries(controlled_jaco_simulation_demo
         ros_joint_state_publisher
         ros_tf_publisher
         ros_subscriber_system)
+
+###################
+# Install targets #
+###################
+
+# Binaries
+install(TARGETS controlled_jaco_simulation_demo jaco_passive_simulation_demo
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+# Libraries
+install(TARGETS ros_subscriber_system
+                ros_publisher_system
+                ros_tf_publisher
+                ros_joint_state_publisher
+                jaco_common
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+# Headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/package.xml
+++ b/package.xml
@@ -14,5 +14,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -4,63 +4,15 @@
   <version>0.0.0</version>
   <description>The kumonoito package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="naveenoid@todo.todo">naveenoid</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>TODO</license>
 
+  <build_depend>ros_drake</build_depend>
+  <build_depend>robot_state_publisher</build_depend>
+  <build_depend>tinyxml2</build_depend> <!-- REMOVE THIS -->
+  <build_depend>libglib-dev</build_depend> <!-- REMOVE THIS -->
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/kumonoito</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>genmsg</build_depend>
-  <exec_depend>genmsg</exec_depend>
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>kumonoito</name>
-  <version>0.0.0</version>
-  <description>The kumonoito package</description>
+  <version>0.0.1</version>
+  <description>
+  This repository exemplifies Drake simulations and systems that communicate
+  via ROS and LCM messages
+  </description>
 
   <maintainer email="naveenoid@todo.todo">naveenoid</maintainer>
-  <license>TODO</license>
-
-  <build_depend>ros_drake</build_depend>
-  <build_depend>robot_state_publisher</build_depend>
+  <license>BSD-3-Clause</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
+
+  <build_depend>ros_drake</build_depend>
+
+  <depend>joint_state_publisher</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>roscpp</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>sensor_msgs</depend>
+
+  <!-- tf is only used in launch files -->
+  <exec_depend>tf</exec_depend>
+
+  <build_export_depend>ros_drake</build_export_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,6 @@
 
   <build_depend>ros_drake</build_depend>
   <build_depend>robot_state_publisher</build_depend>
-  <build_depend>tinyxml2</build_depend> <!-- REMOVE THIS -->
-  <build_depend>libglib-dev</build_depend> <!-- REMOVE THIS -->
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>


### PR DESCRIPTION
This PR change the current kumonoito code to use the [`ros_drake` wrapper](https://github.com/osrf/ros_drake). The wrapper exports automatically the Drake configurations to CATKIN_* variables so the user does not need to include them in the CMakeLists.txt.

The ros_drake wrapper can be installed from the [OSRF drake repo](
 http://packages.osrfoundation.org/gazebo/ubuntu-drake/) available for ROS Kinetic on Ubuntu Xenial by running:
```
sudo echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-drake xenial main" >\
                                                /etc/apt/sources.list.d/osrf.drake.list
sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
sudo apt-get update
sudo apt-get install ros-kinetic-ros-drake
```
**Testing:**
 * Success run with this PR:  https://build.osrfoundation.org/view/All/job/ros_drake-install-xenial-amd64/38/
 * Error message if it can not find drake: https://build.osrfoundation.org/view/All/job/ros_drake-install-xenial-amd64/35/console


I've also included a massive cleanup of all the templates generated by catkin_create_package.




<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naveenoid/kumonoito/6)
<!-- Reviewable:end -->
